### PR TITLE
Centralize app data initialization

### DIFF
--- a/babytracker-pro/src/app/checklist/page.tsx
+++ b/babytracker-pro/src/app/checklist/page.tsx
@@ -97,15 +97,7 @@ export default function EnhancedChecklistPage() {
   // Get current baby from store
   const { currentBaby, initializeData, initializeProfile } = useBabyTrackerStore()
 
-  useEffect(() => {
-    // Check for stored email and initialize profile from database
-    const storedEmail = typeof window !== 'undefined' ? localStorage.getItem('user-email') : null
-    if (storedEmail && storedEmail !== 'nouveau.utilisateur@example.com') {
-      console.log('Checklist page: initializing profile for email:', storedEmail)
-      initializeProfile(storedEmail)
-    }
-    initializeData()
-  }, [initializeData, initializeProfile])
+
 
   const ageInWeeks = currentBaby ? getAgeInWeeks(currentBaby.birthDate) : 0
 

--- a/babytracker-pro/src/app/diaper/page.tsx
+++ b/babytracker-pro/src/app/diaper/page.tsx
@@ -107,15 +107,7 @@ export default function DiaperPage() {
   })
 
 
-  useEffect(() => {
-    // Check for stored email and initialize profile from database
-    const storedEmail = typeof window !== 'undefined' ? localStorage.getItem('user-email') : null
-    if (storedEmail && storedEmail !== 'nouveau.utilisateur@example.com') {
-      console.log('Diaper page: initializing profile for email:', storedEmail)
-      initializeProfile(storedEmail)
-    }
-    initializeData()
-  }, [initializeData, initializeProfile])
+
 
   const ageInWeeks = currentBaby ? getAgeInWeeks(currentBaby.birthDate) : 0
 

--- a/babytracker-pro/src/app/feeding/page.tsx
+++ b/babytracker-pro/src/app/feeding/page.tsx
@@ -308,15 +308,6 @@ export default function FeedingPage() {
   })
 
   // ✅ TOUS les useEffect d'abord
-  useEffect(() => {
-    // Check for stored email and initialize profile from database
-    const storedEmail = typeof window !== 'undefined' ? localStorage.getItem('user-email') : null
-    if (storedEmail && storedEmail !== 'nouveau.utilisateur@example.com') {
-      console.log('Feeding page: initializing profile for email:', storedEmail)
-      initializeProfile(storedEmail)
-    }
-    initializeData()
-  }, [initializeData, initializeProfile])
 
   useEffect(() => {
     let interval: NodeJS.Timeout

--- a/babytracker-pro/src/app/growth/page.tsx
+++ b/babytracker-pro/src/app/growth/page.tsx
@@ -638,15 +638,6 @@ export default function AdvancedGrowthPage() {
   } = useBabyTrackerStore()
 
   // ✅ TOUS les useEffect
-  useEffect(() => {
-    // Check for stored email and initialize profile from database
-    const storedEmail = typeof window !== 'undefined' ? localStorage.getItem('user-email') : null
-    if (storedEmail && storedEmail !== 'nouveau.utilisateur@example.com') {
-      console.log('Growth page: initializing profile for email:', storedEmail)
-      initializeProfile(storedEmail)
-    }
-    initializeData()
-  }, [initializeData, initializeProfile])
 
   // ✅ Load milestones from database
   // ✅ Enhanced milestones loading with error handling

--- a/babytracker-pro/src/app/layout.tsx
+++ b/babytracker-pro/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
 import { ThemeProvider } from '@/contexts/ThemeContext'
+import DataInitializer from '@/components/DataInitializer'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -59,6 +60,7 @@ export default function RootLayout({
         suppressHydrationWarning={true}
       >
         <ThemeProvider>
+          <DataInitializer />
           {children}
         </ThemeProvider>
       </body>

--- a/babytracker-pro/src/app/page.tsx
+++ b/babytracker-pro/src/app/page.tsx
@@ -292,38 +292,9 @@ export default function HomePage() {
 
   // Initialize data and update current time
   useEffect(() => {
-    // Clean up any old default user data from localStorage
-    const storedEmail = typeof window !== 'undefined' ? localStorage.getItem('user-email') : null
-    if (storedEmail === 'nouveau.utilisateur@example.com') {
-      console.log('Clearing old default user data')
-      if (typeof window !== 'undefined') {
-        localStorage.removeItem('user-email')
-        // Clear the entire babytracker storage to reset to clean state
-        localStorage.removeItem('babytracker-storage')
-        // Force page reload to start completely fresh
-        window.location.reload()
-      }
-      return
-    }
-    
-    // Check if there's a stored email and try to load profile
-    const validStoredEmail = typeof window !== 'undefined' ? localStorage.getItem('user-email') : null
-    if (validStoredEmail && validStoredEmail !== 'nouveau.utilisateur@example.com') {
-      console.log('Found stored email, trying to load profile:', validStoredEmail)
-      setEmail(validStoredEmail)
-      // Initialize profile with the stored email
-      initializeProfile(validStoredEmail)
-    } else {
-      console.log('No stored email found, will show email entry screen')
-      // Initialize without email - this will set loading to false and profile to null
-      initializeProfile()
-    }
-    
-    initializeData()
-    
-    const timer = setInterval(() => setCurrentTime(new Date()), 30000) // ✅ Moins fréquent
+    const timer = setInterval(() => setCurrentTime(new Date()), 30000)
     return () => clearInterval(timer)
-  }, [initializeData, initializeProfile])
+  }, [])
 
   // Show loading screen while checking for user profile
   if (isLoading) {

--- a/babytracker-pro/src/app/parent-health/page.tsx
+++ b/babytracker-pro/src/app/parent-health/page.tsx
@@ -301,19 +301,7 @@ export default function ParentHealthPage() {
   
   const { userProfile, currentBaby, initializeProfile } = useBabyTrackerStore()
 
-  // ✅ Initialize profile if missing (after F5 refresh)
-  useEffect(() => {
-    if (!userProfile) {
-      const storedEmail = localStorage.getItem('user-email')
-      if (storedEmail) {
-        console.log('Parent Health: No profile found but email in localStorage, initializing...')
-        initializeProfile(storedEmail)
-      } else {
-        console.log('Parent Health: No profile and no stored email, user needs to log in')
-        setLoading(prev => ({ ...prev, initialLoad: false }))
-      }
-    }
-  }, [userProfile, initializeProfile])
+
 
   // ✅ Enhanced data loading with retry logic and error handling  
   const loadDataWithRetry = useCallback(async (url: string, retries = 2): Promise<any> => {

--- a/babytracker-pro/src/app/profile/page.tsx
+++ b/babytracker-pro/src/app/profile/page.tsx
@@ -119,21 +119,7 @@ export default function ProfilePage() {
     isLoading
   } = useBabyTrackerStore()
 
-  useEffect(() => {
-    // Get email from localStorage (set by homepage)
-    const storedEmail = typeof window !== 'undefined' ? localStorage.getItem('user-email') : null
-    
-    if (storedEmail) {
-      console.log('Profile page loading for email:', storedEmail)
-      initializeProfile(storedEmail)
-    } else {
-      console.log('No email found, redirecting to homepage')
-      window.location.href = '/'
-      return
-    }
-    
-    initializeData()
-  }, [initializeData, initializeProfile])
+
 
  useEffect(() => {
     if (familyMembers.length === 0) {

--- a/babytracker-pro/src/app/sleep/page.tsx
+++ b/babytracker-pro/src/app/sleep/page.tsx
@@ -537,15 +537,7 @@ export default function SleepPage() {
   })
 
   // Initialize data on mount
-  useEffect(() => {
-    // Check for stored email and initialize profile from database
-    const storedEmail = typeof window !== 'undefined' ? localStorage.getItem('user-email') : null
-    if (storedEmail && storedEmail !== 'nouveau.utilisateur@example.com') {
-      console.log('Sleep page: initializing profile for email:', storedEmail)
-      initializeProfile(storedEmail)
-    }
-    initializeData()
-  }, [initializeData, initializeProfile])
+
 
   // Real-time timer effect
   useEffect(() => {

--- a/babytracker-pro/src/components/DataInitializer.tsx
+++ b/babytracker-pro/src/components/DataInitializer.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useBabyTrackerStore } from '@/lib/store'
+
+export default function DataInitializer() {
+  const { initializeProfile, initializeData } = useBabyTrackerStore()
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const storedEmail = localStorage.getItem('user-email')
+    if (storedEmail === 'nouveau.utilisateur@example.com') {
+      localStorage.removeItem('user-email')
+      localStorage.removeItem('babytracker-storage')
+      window.location.reload()
+      return
+    }
+
+    if (storedEmail) {
+      initializeProfile(storedEmail)
+    }
+    initializeData()
+  }, [initializeProfile, initializeData])
+
+  return null
+}


### PR DESCRIPTION
## Summary
- add `DataInitializer` to load stored user profiles on mount
- render `DataInitializer` from `RootLayout`
- remove initialization logic from individual pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884ddd172308321a618aa97ad140b00